### PR TITLE
Switch to Ubuntu from Fedora

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,19 @@
-FROM fedora:35
+FROM ubuntu:23.04
+
 # Make sure all sources are up to date
-RUN dnf update -y && \
-    dnf install -y \
-        python3 python3-pip python3-devel \
-        gcc clang git gdb make libasan libubsan liblsan libtsan \
-        findutils bzip2 e2fsprogs \
-        --nodocs --setopt install_weak_deps=False && \
-    dnf clean all -y
+RUN apt update && \
+        apt upgrade -y --autoremove && \
+        apt install -y --no-install-recommends \
+                python3 python3-pip python3-dev \
+                gcc clang git gdb make \
+                findutils bzip2 e2fsprogs sudo && \
+        apt clean && rm -rf /var/lib/apt/lists/*
+
 # UserID 5000 required for Artemis Build Infrastructure
 RUN useradd --uid 5000 artemis_user
+
 # Give the artemis_user sudo rights without a password by default
 RUN echo "artemis_user     ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers
+
 # Change the user to the default Artemis user (away from root)
 USER artemis_user


### PR DESCRIPTION
This is to keep this somewhat in sync with the lxhalle, which many students use for development and testing.