### PR TITLE
Fix failing "pip install" in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ FROM ubuntu:23.04
 RUN apt update && \
         apt upgrade -y --autoremove && \
         apt install -y --no-install-recommends \
-                python3 python3-pip python3-dev \
+                python3 python3-pip python3-dev python3-psutil \
                 gcc clang git gdb make \
                 findutils bzip2 e2fsprogs sudo && \
         apt clean && rm -rf /var/lib/apt/lists/*
 
 # UserID 5000 required for Artemis Build Infrastructure
-RUN useradd --uid 5000 artemis_user
+RUN useradd -m --uid 5000 artemis_user
 
 # Give the artemis_user sudo rights without a password by default
 RUN echo "artemis_user     ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers


### PR DESCRIPTION
Inside the container, `pip3 install --user` fails, as there exists no home directory for the new user created by `useradd`. This issue was introduced in #17, as Ubuntu's `useradd` does not create a corresponding home directory by default, whereas Fedora's `useradd` does. Now, we run `useradd` with `-m` to explicitly request a new home directory.

While we're at it: We're currently installing `psutil` for each tester run on half of our assignments. Installing a package several thousand times is an unnecessary strain on the infrastructure. Let's add it to the image once and we're good.